### PR TITLE
fix #6 - classpath for gwt compiler portability issues 

### DIFF
--- a/vertxui-core/src/main/java/live/connector/vertxui/server/VertxUI.java
+++ b/vertxui-core/src/main/java/live/connector/vertxui/server/VertxUI.java
@@ -253,7 +253,7 @@ public class VertxUI {
 				? (System.getProperty("java.class.path").contains(";") ? ";" : ":")
 				: System.getenv("path.separator");
 		String classpath = System.getProperty("java.class.path");
-		classpath = "\"" + classpath + separator + new File(folderSource).getAbsolutePath() + "\"";
+		classpath = '"' + separator + classpath + separator + new File(folderSource).getAbsolutePath()  + separator + '"';
 		log.fine("Classpath = " + classpath);
 
 		// Check whether the classpath contains gwt


### PR DESCRIPTION
[documentation of the fix](https://gist.github.com/rondinif/7682ccbd3fa35d3f91225047e82d3e5d)

Hi Niels, 
To get more awareness of what happens on my OSX env. I ended up to temporarily substitute the invocation of gwt with the invocation of my test java class and carefully analyze whith `ps -ef | grep java` what happen when I run the same command line in a terminal (bash); this led me to conclude that when running in a bash the `classpath` arrives "cleaned" by the double quotes to the class that we finally invoke ( i.e: com.google.gwt.dev.Compiler or my temporary sostitution class ) BUT when passing the commandline to `java.lang.Process` the classpath mantains quotes and these quotes could taint someway the classpath or anyway prevent correct operation; THEREFORE I decided to test by prependind and postpending a path separator (ie: `System.getenv("path.separator")` at the start and at the end of class path, near to the quote delimiters to avoid a tainting effect of these delimiters. Tests oucomes lead to think that this workaround can do the trick, further tests could still be needed to confirm the portability of the solution on different OS.
