### PR TITLE
Fixed bug that prevents to attach-javadocs

### DIFF
--- a/vertxui-core/src/main/java/live/connector/vertxui/client/fluent/FluentBase.java
+++ b/vertxui-core/src/main/java/live/connector/vertxui/client/fluent/FluentBase.java
@@ -862,7 +862,7 @@ public class FluentBase implements Viewable {
 	/**
 	 * Convenient method to get the given CSS-class attribute.
 	 * 
-	 * @param string
+	 * @param className
 	 *            the CSS-class attribute.
 	 * @return this
 	 */


### PR DESCRIPTION
# vertxui-core: Fixed little bug that prevents to attach-javadocs.
## Bug specs
### Steps to reproduce
```
cd %PROJECT-HOME/vertxui-core
mvn clean package
```
### Actual Results:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project vertxui-core: MavenReportException: Error while creating archive

#[snip]

[ERROR] /Users/ronda/projects/rondinif/vertxui/vertxui-core/src/main/java/live/connector/vertxui/client/fluent/FluentBase.java:865: error: @param name not found
[ERROR] 	 * @param string
```
Expected Results:
```
[INFO] BUILD SUCCESS
```
## PR: proposed fix
```
FluentBase.java
index dea898c..0171ce9 100644
--- a/vertxui-core/src/main/java/live/connector/vertxui/client/fluent/FluentBase.java
+++ b/vertxui-core/src/main/java/live/connector/vertxui/client/fluent/FluentBase.java
@@ -862,7 +862,7 @@ public class FluentBase implements Viewable {
        /**
         * Convenient method to get the given CSS-class attribute.
         * 
-        * @param string
+        * @param className^M
         *            the CSS-class attribute.
         * @return this
         */
```

Even with the proposed change, still there are some WARNs such as: 
```
[WARNING] Javadoc Warnings
[WARNING] javadoc: warning - You have not specified the version of HTML to use.
[WARNING] The default is currently HTML 4.01, but this will change to HTML5
[WARNING] in a future release. To suppress this warning, please specify the
[WARNING] version of HTML used in your documentation comments and to be
[WARNING] generated by this doclet, using the -html4 or -html5 options.
[WARNING] /Users/ronda/projects/rondinif/vertxui/vertxui-core/src/main/java/live/connector/vertxui/client/fluent/Fluent.java:634: warning: no @param for then
[WARNING] public Fluent scriptSync(Consumer<Void> then, String... jss) {
```
which of course should be better to fix but this can have a lower priority since they aren't blocking the effective build process.


