### PR TITLE
avoid `Compilation failure` caused by org.junit does not exist

### DIFF
--- a/empty-project/pom.xml
+++ b/empty-project/pom.xml
@@ -26,7 +26,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
-			<scope>test</scope>
+			<!--scope>test</scope  ..actually used in src/main/java/client/test/ViewTestWithDom.java -->
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION

# vertxui/empty-project: attempt to fix pom.xml to avoid `Compilation failure` caused by `org.junit does not exist`.
## Bug specs
### Steps to reproduce
```
cd %PROJECT-HOME/empty-project
mvn clean package
```
### Actual Results:
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/ronda/projects/rondinif/vertxui/empty-project/src/main/java/client/test/ViewTestWithDom.java:[9,17] package org.junit does not exist
[ERROR] /Users/ronda/projects/rondinif/vertxui/empty-project/src/main/java/client/test/ViewTestWithDom.java:[24,10] cannot find symbol
  symbol:   class Test
  location: class client.test.ViewTestWithDom
```
Expected Results:
```
[INFO] BUILD SUCCESS
```
## PR: proposed fix
```
--- a/empty-project/pom.xml
+++ b/empty-project/pom.xml
@@ -26,7 +26,7 @@
                        <groupId>junit</groupId>
                        <artifactId>junit</artifactId>
                        <version>4.12</version>
-                       <scope>test</scope>
+                       <!--scope>test</scope  ..actually used in src/main/java/client/test/ViewTestWithDom.java -->^M
                </dependency>
                <dependency>
                        <groupId>org.mockito</groupId>
```